### PR TITLE
fix: use oidc for all flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,12 @@
 PUBLIC_URL=https://127.0.0.1:3000
+
+# Integrated OAuth2 server configuration
 JWT_SECRET=your-secret-key-here-minimum-32-characters
 AUTH_CLIENT_ID=root
 AUTH_CLIENT_SECRET=root
+
+# External OIDC provider configuration (e.g., Keycloak)
+# Uncomment and configure these to use external OIDC provider
+#OIDC=true
+#KEYCLOAK_INTERNAL_ISSUER_URL=https://your-keycloak.example.com/realms/your-realm
+#KEYCLOAK_CLIENT_ID=your-client-id

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker run -p 3000:3000 \
   ghcr.io/cre8/eudiplo:latest
 
 # Get a token and start using the API
-curl -X POST http://localhost:3000/auth/token \
+curl -X POST http://localhost:3000/auth/oauth2/token \
   -H "Content-Type: application/json" \
   -d '{
     "client_id": "root",

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,15 +1,8 @@
 # API Authentication
 
-The EUDIP1. **Swagger UI Authentication:**
-
-- Navigate to the Swagger UI at `/api`
-- Click the "Authorize" button
-- Select "oauth2"
-- Enter client ID and secret (default: `root`/`root`)
-- The Swagger UI will automatically send credentials in the Authorization header
-  (Basic auth)rvice API uses OAuth2 client credentials flow for all
-  authentication, providing a unified approach that works with both integrated
-  OAuth2 server and external OIDC providers.
+The EUDIPLO Service API uses OAuth2 client credentials flow for all
+authentication, providing a unified approach that works with both integrated
+OAuth2 server and external OIDC providers.
 
 ## OAuth2 Client Credentials Authentication
 
@@ -42,6 +35,8 @@ When using the built-in OAuth2 server:
     - Click the "Authorize" button
     - Select "oauth2"
     - Enter client ID and secret (default: `root`/`root`)
+    - The Swagger UI will automatically send credentials in the Authorization
+      header (Basic auth)
 
 2. **Programmatic Access (Client Credentials Flow):**
 
@@ -100,14 +95,6 @@ All administrative endpoints require OAuth2 authentication:
 - **Presentation Management** (`/presentation-management/*`) - Presentation
   verification management
 - **Session Management** (`/session/*`) - Session lifecycle management
-
-## Migration from Bearer Tokens
-
-If you were previously using the `/auth/token` endpoint for JWT tokens, no
-changes are required - this endpoint now internally uses the OAuth2 client
-credentials flow for backward compatibility.
-
-## Troubleshooting
 
 ## Troubleshooting
 

--- a/docs/development/api-authentication.md
+++ b/docs/development/api-authentication.md
@@ -1,0 +1,133 @@
+# API Authentication
+
+The EUDIP1. **Swagger UI Authentication:**
+
+- Navigate to the Swagger UI at `/api`
+- Click the "Authorize" button
+- Select "oauth2"
+- Enter client ID and secret (default: `root`/`root`)
+- The Swagger UI will automatically send credentials in the Authorization header
+  (Basic auth)rvice API uses OAuth2 client credentials flow for all
+  authentication, providing a unified approach that works with both integrated
+  OAuth2 server and external OIDC providers.
+
+## OAuth2 Client Credentials Authentication
+
+This API exclusively uses the OAuth2 client credentials flow, which is designed
+for service-to-service authentication where no user interaction is required.
+
+### External OIDC Provider (e.g., Keycloak)
+
+When configured with an external OIDC provider:
+
+1. **Swagger UI Authentication:**
+    - Navigate to the Swagger UI at `/api`
+    - Click the "Authorize" button
+    - Select "oauth2"
+    - Enter your client ID and client secret
+    - Click "Authorize"
+    - The Swagger UI will automatically send credentials in the Authorization
+      header (Basic auth)
+
+2. **Programmatic Access:**
+    - Use your OIDC provider's token endpoint with client credentials flow
+    - Include the access token in API requests: `Authorization: Bearer <token>`
+
+### Integrated OAuth2 Server
+
+When using the built-in OAuth2 server:
+
+1. **Swagger UI Authentication:**
+    - Navigate to the Swagger UI at `/api`
+    - Click the "Authorize" button
+    - Select "oauth2"
+    - Enter client ID and secret (default: `root`/`root`)
+
+2. **Programmatic Access (Client Credentials Flow):**
+
+    **Option 1: Credentials in Authorization Header (Recommended for OAuth2
+    compliance):**
+
+    ```bash
+    curl -X POST http://localhost:3000/auth/oauth2/token \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Basic $(echo -n 'root:root' | base64)" \
+      -d '{
+        "grant_type": "client_credentials"
+      }'
+    ```
+
+    **Option 2: Credentials in Request Body:**
+
+    ```bash
+    curl -X POST http://localhost:3000/auth/oauth2/token \
+      -H "Content-Type: application/json" \
+      -d '{
+        "grant_type": "client_credentials",
+        "client_id": "root",
+        "client_secret": "root"
+      }'
+    ```
+
+## Configuration
+
+### External OIDC Provider
+
+```bash
+# Enable external OIDC
+OIDC=true
+KEYCLOAK_INTERNAL_ISSUER_URL=https://your-keycloak.example.com/realms/your-realm
+KEYCLOAK_CLIENT_ID=your-client-id
+PUBLIC_URL=https://your-api.example.com
+```
+
+### Integrated OAuth2 Server
+
+```bash
+# Leave OIDC undefined for integrated OAuth2 server
+PUBLIC_URL=https://your-api.example.com
+JWT_SECRET=your-secret-key-here-minimum-32-characters
+AUTH_CLIENT_ID=root
+AUTH_CLIENT_SECRET=root
+```
+
+## Protected Endpoints
+
+All administrative endpoints require OAuth2 authentication:
+
+- **Issuer Management** (`/issuer-management/*`) - Credential issuance
+  management
+- **Presentation Management** (`/presentation-management/*`) - Presentation
+  verification management
+- **Session Management** (`/session/*`) - Session lifecycle management
+
+## Migration from Bearer Tokens
+
+If you were previously using the `/auth/token` endpoint for JWT tokens, no
+changes are required - this endpoint now internally uses the OAuth2 client
+credentials flow for backward compatibility.
+
+## Troubleshooting
+
+## Troubleshooting
+
+### Token Validation Errors
+
+1. Verify that tokens include the correct audience (`eudiplo-service`)
+2. Ensure clock synchronization between client and server
+3. Check token expiration times
+
+### Integrated OAuth2 Server Issues
+
+1. Verify `JWT_SECRET` is at least 32 characters
+2. Ensure client credentials (`AUTH_CLIENT_ID`/`AUTH_CLIENT_SECRET`) are
+   configured correctly
+3. Check that `PUBLIC_URL` is accessible for OAuth2 flows
+
+## Security Considerations
+
+- **Token Lifetime**: Tokens expire after 24 hours for client credentials flow
+- **Secure Storage**: Store client credentials and tokens securely and never
+  expose them in logs or URLs
+- **Service-to-Service**: This API is designed for service-to-service
+  authentication without user interaction

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -32,7 +32,7 @@ Each module typically contains its own:
 
 ## Additional Documentation
 
-- [API Authentication](api-authentication.md) - Guide for using JWT and OAuth2
+- [API Authentication](../api/authentication.md) - Guide for using OAuth2
   authentication with the API
 - [Contributing Guidelines](contributing.md) - How to contribute to the project
 - [Testing Guide](testing.md) - How to run and write tests

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -30,6 +30,14 @@ Each module typically contains its own:
 - `dto/` — Data Transfer Objects
 - `entities/` — TypeORM entities (if needed)
 
+## Additional Documentation
+
+- [API Authentication](api-authentication.md) - Guide for using JWT and OAuth2
+  authentication with the API
+- [Contributing Guidelines](contributing.md) - How to contribute to the project
+- [Testing Guide](testing.md) - How to run and write tests
+- [Session Logging](session-logging.md) - Understanding session logging
+
 ## Scripts
 
 Useful development scripts:

--- a/docs/getting-started/management.md
+++ b/docs/getting-started/management.md
@@ -16,7 +16,7 @@ This approach is recommended when you just want to manage one instance.
 ```bash
 # Get JWT token from EUDIPLO
 curl -X 'POST' \
-  'http://localhost:3000/auth/token' \
+  'http://localhost:3000/auth/oauth2/token' \
   -H 'Content-Type: application/json' \
   -d '{
     "client_id": "your-tenant-id",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - Database: architecture/database.md      
   - API:    
     - Overview: api/index.md    
+    - Authentication: api/authentication.md
   - Development:
       - development/index.md
       - Versioning: development/versioning.md

--- a/scripts/import.ts
+++ b/scripts/import.ts
@@ -11,7 +11,7 @@ type LoginReponse = {
 };
 
 async function run() {
-    const accessToken = await fetch(`${url}/auth/token`, {
+    const accessToken = await fetch(`${url}/auth/oauth2/token`, {
         method: 'POST',
         headers: {
             accept: 'application/json',

--- a/src/auth/dto/token-response.dto.ts
+++ b/src/auth/dto/token-response.dto.ts
@@ -1,5 +1,5 @@
 export class TokenResponse {
     access_token: string;
     token_type: 'Bearer';
-    expires_in: string;
+    expires_in: number;
 }

--- a/src/auth/jwt.service.ts
+++ b/src/auth/jwt.service.ts
@@ -14,15 +14,15 @@ export class JwtService {
     constructor(private configService: ConfigService) {}
 
     /**
-     * Generate a JWT token for single-tenant mode
+     * Generate a JWT token for integrated OAuth2 server
      */
     async generateToken(
         payload: TokenPayload,
         options: GenerateTokenOptions = {},
     ): Promise<string> {
-        if (this.isMultiTenant()) {
+        if (this.isUsingExternalOIDC()) {
             throw new Error(
-                'Token generation is not available in multi-tenant mode. Use Keycloak for token generation.',
+                'Token generation is not available when using external OIDC provider. Use your external OIDC provider for token generation.',
             );
         }
 
@@ -54,9 +54,9 @@ export class JwtService {
      * Verify a JWT token (for additional validation if needed)
      */
     async verifyToken(token: string): Promise<TokenPayload> {
-        if (this.isMultiTenant()) {
+        if (this.isUsingExternalOIDC()) {
             throw new Error(
-                'Token verification is handled by Keycloak in multi-tenant mode.',
+                'Token verification is handled by external OIDC provider.',
             );
         }
 
@@ -89,9 +89,9 @@ export class JwtService {
     }
 
     /**
-     * Check if the service is in multi-tenant mode
+     * Check if the service is using external OIDC provider
      */
-    isMultiTenant(): boolean {
+    isUsingExternalOIDC(): boolean {
         return this.configService.get<string>('OIDC') !== undefined;
     }
 }

--- a/src/issuer/issuer-management/issuer-management.controller.ts
+++ b/src/issuer/issuer-management/issuer-management.controller.ts
@@ -27,7 +27,7 @@ import { Response } from 'express';
 
 @ApiTags('Issuer management', 'Admin')
 @UseGuards(JwtAuthGuard)
-@ApiSecurity('bearer')
+@ApiSecurity('oauth2')
 @Controller('issuer-management')
 export class IssuerManagementController {
     constructor(

--- a/src/session/session.controller.ts
+++ b/src/session/session.controller.ts
@@ -9,7 +9,7 @@ import { StatusListService } from '../issuer/status-list/status-list.service';
 
 @ApiTags('Session management', 'Admin')
 @UseGuards(JwtAuthGuard)
-@ApiSecurity('bearer')
+@ApiSecurity('oauth2')
 @Controller('session')
 export class SessionController {
     constructor(
@@ -38,8 +38,6 @@ export class SessionController {
      * @param value
      * @returns
      */
-    @UseGuards(JwtAuthGuard)
-    @ApiSecurity('bearer')
     @Post('revoke')
     revokeAll(@Body() value: StatusUpdateDto, @Token() user: TokenPayload) {
         return this.statusListService.updateStatus(value, user.sub);

--- a/src/verifier/presentations/presentations.controller.ts
+++ b/src/verifier/presentations/presentations.controller.ts
@@ -30,7 +30,7 @@ import { Response } from 'express';
 
 @ApiTags('Presentation management', 'Admin')
 @UseGuards(JwtAuthGuard)
-@ApiSecurity('bearer')
+@ApiSecurity('oauth2', ['api:read', 'api:write'])
 @Controller('presentation-management')
 export class PresentationManagementController {
     constructor(
@@ -55,7 +55,7 @@ export class PresentationManagementController {
     })
     @ApiProduces('application/json', 'image/png')
     @UseGuards(JwtAuthGuard)
-    @ApiSecurity('bearer')
+    @ApiSecurity('oauth2')
     @ApiBody({
         type: PresentationRequest,
         examples: {

--- a/test/issuance.e2e-spec.ts
+++ b/test/issuance.e2e-spec.ts
@@ -56,7 +56,7 @@ describe('Issuance', () => {
 
         // Get JWT token using client credentials
         const tokenResponse = await request(app.getHttpServer())
-            .post('/auth/token')
+            .post('/auth/oauth2/token')
             .trustLocalhost()
             .send({
                 client_id: clientId,

--- a/test/issuance.e2e-spec.ts
+++ b/test/issuance.e2e-spec.ts
@@ -61,6 +61,7 @@ describe('Issuance', () => {
             .send({
                 client_id: clientId,
                 client_secret: clientSecret,
+                grant_type: 'client_credentials',
             });
 
         authToken = tokenResponse.body.access_token;

--- a/test/presentation.e2e-spec.ts
+++ b/test/presentation.e2e-spec.ts
@@ -34,7 +34,7 @@ describe('Presentation', () => {
 
         // Get JWT token using client credentials
         const tokenResponse = await request(app.getHttpServer())
-            .post('/auth/token')
+            .post('/auth/oauth2/token')
             .trustLocalhost()
             .send({
                 client_id: clientId,

--- a/test/presentation.e2e-spec.ts
+++ b/test/presentation.e2e-spec.ts
@@ -39,6 +39,7 @@ describe('Presentation', () => {
             .send({
                 client_id: clientId,
                 client_secret: clientSecret,
+                grant_type: 'client_credentials',
             });
 
         authToken = tokenResponse.body.access_token;


### PR DESCRIPTION
uses oidc also for internal client handling instead of custom endpoint. Also improve swagger config

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>